### PR TITLE
feat: pull copa image

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,6 @@ jobs:
             images: ['docker.io/library/nginx:1.21.6', 'docker.io/openpolicyagent/opa:0.46.0', 'docker.io/library/hello-world:latest']
 
         steps:
-        - name: Checkout repository
-          uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v0.1.0
-          with:
-            repository: project-copacetic/copa-action
-            ref: main
-
         - name: Set up Docker Buildx
           uses: docker/setup-buildx-action@ecf95283f03858871ff00b787d79c419715afc34
 

--- a/action.yaml
+++ b/action.yaml
@@ -26,11 +26,11 @@ runs:
       run: |
         if [ -z "${{ inputs.copa-version }}" ]; then
           latest_tag=$(curl -s "https://api.github.com/repos/project-copacetic/copacetic/releases/latest" | jq -r '.tag_name')
-          latest_version="${latest:1}"
+          copa_version="${latest:1}"
         else
-          latest_version=${{ inputs.copa-version }}
+          copa_version=${{ inputs.copa-version }}
         fi
-        docker build --build-arg copa_version=${latest_version} -t copa-action .
+        docker pull ghcr.io/project-copacetic/copa-action/copa-action:v${copa_version}
     - name: docker run buildkitd
       shell: bash
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -21,16 +21,18 @@ outputs:
 runs:
   using: "composite"
   steps: 
-    - name: docker build copa-action
+    - name: docker pull copa-action
       shell: bash
       run: |
         if [ -z "${{ inputs.copa-version }}" ]; then
           latest_tag=$(curl -s "https://api.github.com/repos/project-copacetic/copacetic/releases/latest" | jq -r '.tag_name')
-          copa_version="${latest:1}"
+          version=${latest_tag:1}
         else
-          copa_version=${{ inputs.copa-version }}
+          version="${{ inputs.copa-version }}"
         fi
-        docker pull ghcr.io/project-copacetic/copa-action/copa-action:v${copa_version}
+        docker pull "ghcr.io/project-copacetic/copa-action/copa-action:v$version"
+        docker tag "ghcr.io/project-copacetic/copa-action/copa-action:v$version" copa-action:latest
+        docker images
     - name: docker run buildkitd
       shell: bash
       run: |
@@ -39,4 +41,4 @@ runs:
       id: copa-action
       shell: bash
       run : |
-        docker run --net=host --mount=type=bind,source=$(pwd),target=/data --mount=type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock --mount=type=bind,source=$GITHUB_OUTPUT,target=$GITHUB_OUTPUT -e GITHUB_OUTPUT --name=copa-action copa-action ${{ inputs.image }} ${{ inputs.image-report }} ${{ inputs.patched-tag }}
+        docker run --net=host --mount=type=bind,source=$(pwd),target=/data --mount=type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock --mount=type=bind,source=$GITHUB_OUTPUT,target=$GITHUB_OUTPUT -e GITHUB_OUTPUT --name=copa-action copa-action:latest ${{ inputs.image }} ${{ inputs.image-report }} ${{ inputs.patched-tag }}

--- a/action.yaml
+++ b/action.yaml
@@ -21,18 +21,6 @@ outputs:
 runs:
   using: "composite"
   steps: 
-    - name: docker pull copa-action
-      shell: bash
-      run: |
-        if [ -z "${{ inputs.copa-version }}" ]; then
-          latest_tag=$(curl -s "https://api.github.com/repos/project-copacetic/copacetic/releases/latest" | jq -r '.tag_name')
-          version=${latest_tag:1}
-        else
-          version="${{ inputs.copa-version }}"
-        fi
-        docker pull "ghcr.io/project-copacetic/copa-action/copa-action:v$version"
-        docker tag "ghcr.io/project-copacetic/copa-action/copa-action:v$version" copa-action:latest
-        docker images
     - name: docker run buildkitd
       shell: bash
       run: |
@@ -41,4 +29,10 @@ runs:
       id: copa-action
       shell: bash
       run : |
-        docker run --net=host --mount=type=bind,source=$(pwd),target=/data --mount=type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock --mount=type=bind,source=$GITHUB_OUTPUT,target=$GITHUB_OUTPUT -e GITHUB_OUTPUT --name=copa-action copa-action:latest ${{ inputs.image }} ${{ inputs.image-report }} ${{ inputs.patched-tag }}
+        if [ -z "${{ inputs.copa-version }}" ]; then
+          latest_tag=$(curl -s "https://api.github.com/repos/project-copacetic/copacetic/releases/latest" | jq -r '.tag_name')
+          version=${latest_tag:1}
+        else
+          version="${{ inputs.copa-version }}"
+        fi
+        docker run --net=host --mount=type=bind,source=$(pwd),target=/data --mount=type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock --mount=type=bind,source=$GITHUB_OUTPUT,target=$GITHUB_OUTPUT -e GITHUB_OUTPUT --name=copa-action "ghcr.io/project-copacetic/copa-action/copa-action:v$version" ${{ inputs.image }} ${{ inputs.image-report }} ${{ inputs.patched-tag }}


### PR DESCRIPTION
Fixes #3. Changes copa action to pull respective copa-action image instead of checkout action repo. Copa action image corresponds 1-1 with copa version to use.