### PR TITLE
fix: curl command null version returned

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ This action patches vulnerable containers using [Copa](https://github.com/projec
 
 **Required** The new patched image tag.
 
+## `buildkit-version`
+
+**Optional** The buildkit version used in the action, default is latest.
+
 ## `copa-version`
 
 **Optional** The Copa version used in the action, default is latest.

--- a/action.yaml
+++ b/action.yaml
@@ -24,7 +24,11 @@ runs:
     - name: docker run buildkitd
       shell: bash
       run: |
-        docker run --net=host --detach --rm --privileged -p 127.0.0.1:8888:8888 --name buildkitd --entrypoint buildkitd moby/buildkit:${{ inputs.buildkit-version }} --addr tcp://0.0.0.0:8888
+        if [ -z "${{ inputs.buildkit-version }}" ]; then
+          docker run --net=host --detach --rm --privileged -p 127.0.0.1:8888:8888 --name buildkitd --entrypoint buildkitd moby/buildkit:latest --addr tcp://0.0.0.0:8888
+        else
+          docker run --net=host --detach --rm --privileged -p 127.0.0.1:8888:8888 --name buildkitd --entrypoint buildkitd moby/buildkit:${{ inputs.buildkit-version }} --addr tcp://0.0.0.0:8888
+        fi
     - name: docker run copa-action
       id: copa-action
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -34,7 +34,7 @@ runs:
       shell: bash
       run : |
         if [ -z "${{ inputs.copa-version }}" ]; then
-          latest_tag=$(curl -s "https://api.github.com/repos/project-copacetic/copacetic/releases/latest" | jq -r '.tag_name')
+          latest_tag=$(curl --retry 5 -s "https://api.github.com/repos/project-copacetic/copacetic/releases/latest" | jq -r '.tag_name')
           version=${latest_tag:1}
         else
           version="${{ inputs.copa-version }}"


### PR DESCRIPTION
When the curl command occasionally returns null, it leads to "vull" as the copa action image version to pull. This adds a retry to prevent that from happening. 

Fixes #17