### PR TITLE
fix: error in case no openvex output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,9 +29,3 @@ else
     exit 1
 fi
 
-# due to docker, file permissions are set as 400
-# set output file permissions so user can read it
-if [ ! -z "$output_file" ]
-then
-    chmod 444 ./data/"$output_file"
-fi


### PR DESCRIPTION
This fixes #34 

Basically, we can remove the following chmod, introduced in [this PR](https://github.com/project-copacetic/copa-action/pull/29):  
```bash
# due to docker, file permissions are set as 400
# set output file permissions so user can read it
if [ ! -z "$output_file" ]
then
    chmod 444 ./data/"$output_file"
fi
```

This check was improperly executed, in the sense that it did not effectively verify whether the output file is present or not. Additionally, I have observed that the permissions of the file, when present, remain unchanged (likely because changing permissions using `chmod` from within the container does not propagate those changes to the runner, even if the file is mounted via volume):
```console
-r--r--r-- 1 root   root     5890 Feb  8 08:04 docker.io-openpolicyagent-opa-0.46.0-openvex-report.json
-rw-r--r-- 1 root   root   127257 Feb  8 08:03 report.json
```

Since the chmod command does not take effect and can cause the error explained in the related issue, it can be removed.
The upside is that those restrictive file permissions do not seem to be an issue, as it is still possible to access the output artifact in other steps of the job. 
For example, it is possible to `cat` or upload the artifact through this step:
```yaml
- name: Archive openvex vuln report
  uses: actions/upload-artifact@v4
  with:
    name: ${{ env.PATCHED_TAG_SBOM }}-openvex-report
    path: ${{ env.PATCHED_TAG_SBOM }}-openvex-report.json
``` 

